### PR TITLE
Fix function declaration inside block

### DIFF
--- a/example.js
+++ b/example.js
@@ -37,3 +37,12 @@ React = {
 };
 console.log(xml.xml(pojo, React.createElement.bind(React)));
 console.log(xml.xml(pojo, _));
+
+
+var pojo =
+    ['span', null, [
+        ['span', null, '1'],
+        ['span', null, '2'],
+    ]];
+console.log(xml.xml(pojo));
+

--- a/index.js
+++ b/index.js
@@ -24,26 +24,25 @@ function _(name, attributes) {
     return ("<" + name + (attr ? ' ' + attr : '')) + (body ? ">" + body + "</" + name + ">" : '/>');
 }
 exports._ = _;
-// export function xml(pojo) {
-//     var inner = [];
-//     for(var i = 2; i < pojo.length; i++) {
-//         var child = pojo[i];
-//         inner.push(child instanceof Array ? xml.call(null, child) : child);
-//     }
-//
-//     var [name, attributes] = pojo;
-//     var attr = formatAttr(attributes || null);
-//
-//     var body = inner.join('');
-//     return `<${name}${attr ? ' ' + attr : ''}` + (body ? `>${body}</${name}>` : '/>');
-// }
 function xml(pojo, h) {
     if (h === void 0) { h = _; }
     var list = [pojo[0], pojo[1] || null];
     // Add children
     for (var i = 2; i < pojo.length; i++) {
         var child = pojo[i];
-        list.push(child instanceof Array ? xml(child, h) : child);
+        function c(child) {
+            if (child instanceof Array) {
+                // This flattens an array of children, makes compatible with React.
+                if (child[0] instanceof Array)
+                    for (var j = 0; j < child.length; j++)
+                        c(child[j]);
+                else
+                    list.push(xml(child, h));
+            }
+            else
+                list.push(child);
+        }
+        c(child);
     }
     return h.apply(null, list);
 }

--- a/index.js
+++ b/index.js
@@ -30,7 +30,7 @@ function xml(pojo, h) {
     // Add children
     for (var i = 2; i < pojo.length; i++) {
         var child = pojo[i];
-        function c(child) {
+        var c = function(child) {
             if (child instanceof Array) {
                 // This flattens an array of children, makes compatible with React.
                 if (child[0] instanceof Array)

--- a/index.ts
+++ b/index.ts
@@ -24,29 +24,20 @@ export function _(name: string, attributes: Tattributes = {}, ...children: strin
     return `<${name}${attr ? ' ' + attr : ''}` + (body ? `>${body}</${name}>` : '/>');
 }
 
-
-
-// export function xml(pojo) {
-//     var inner = [];
-//     for(var i = 2; i < pojo.length; i++) {
-//         var child = pojo[i];
-//         inner.push(child instanceof Array ? xml.call(null, child) : child);
-//     }
-//
-//     var [name, attributes] = pojo;
-//     var attr = formatAttr(attributes || null);
-//
-//     var body = inner.join('');
-//     return `<${name}${attr ? ' ' + attr : ''}` + (body ? `>${body}</${name}>` : '/>');
-// }
-
 export function xml(pojo, h = _) {
     var list = [pojo[0], pojo[1] || null];
     // Add children
     for(var i = 2; i < pojo.length; i++) {
         var child = pojo[i];
-        list.push(child instanceof Array ? xml(child, h) : child);
+        function c(child) {
+            if(child instanceof Array) {
+                // This flattens an array of children, makes compatible with React.
+                if(child[0] instanceof Array)
+                    for(var j = 0; j < child.length; j++) c(child[j]);
+                else list.push(xml(child, h));
+            } else list.push(child);
+        }
+        c(child);
     }
     return h.apply(null, list);
 }
-

--- a/index.ts
+++ b/index.ts
@@ -29,7 +29,7 @@ export function xml(pojo, h = _) {
     // Add children
     for(var i = 2; i < pojo.length; i++) {
         var child = pojo[i];
-        function c(child) {
+        var c = function(child) {
             if(child instanceof Array) {
                 // This flattens an array of children, makes compatible with React.
                 if(child[0] instanceof Array)

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "xml-light",
   "description": "Write XML in JavaScript",
-  "version": "1.0.6",
+  "version": "1.0.8",
   "keywords": [
     "xml",
     "html",


### PR DESCRIPTION
Hi, Vadim

Here is a fix for the following error that we get when trying to use xml-light in our project:

ERROR at /data/dev/web/node_modules/xml-light/index.ts(32,18): 
TS1252: Function declarations are not allowed inside blocks in strict mode when targeting 'ES3' or 'ES5'. Modules are automatically in strict mode.

https://github.com/ceresnam/xml-light/commit/3750ab10d16f0fd2bce0f00ba5127465704c0135

I had to extract source code for version 1.0.8 from npm, github has source code only for v1.0.6. So, pull request contains also diff of that. Maybe you moved the project to other location?
